### PR TITLE
SPM integration fix for Xcode 13

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -15,13 +15,13 @@ let package = Package(
     ],
     targets: [
         .binaryTarget(
-            name: "OutbrainSDKXCFramework",
+            name: "Outbrain",
             path: "OutbrainSDK.xcframework"
         ),
         .target(
             name: "WrapperSPMTarget",
             dependencies: [
-                .target(name: "OutbrainSDKXCFramework", condition: .when(platforms: .some([.iOS])))
+                .target(name: "Outbrain", condition: .when(platforms: .some([.iOS])))
             ]
         )
     ]

--- a/Package.swift
+++ b/Package.swift
@@ -15,13 +15,13 @@ let package = Package(
     ],
     targets: [
         .binaryTarget(
-            name: "Outbrain",
+            name: "OutbrainSDK",
             path: "OutbrainSDK.xcframework"
         ),
         .target(
             name: "WrapperSPMTarget",
             dependencies: [
-                .target(name: "Outbrain", condition: .when(platforms: .some([.iOS])))
+                .target(name: "OutbrainSDK", condition: .when(platforms: .some([.iOS])))
             ]
         )
     ]


### PR DESCRIPTION
The artifact name has to match the target name with the new Xcode 13.3.
Reference: https://stackoverflow.com/questions/71539013/spm-artifact-not-found-for-target-aaa-xcode-13-3-only